### PR TITLE
Update ignore file to exclude templates folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode/settings.json
 .obsidian/*
+docs/Templates/*


### PR DESCRIPTION
All for future templates folder to be added to Obsidian vault but ignored from repository and GitHub page.